### PR TITLE
Do not throw errors when a get 404s

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -37,7 +37,7 @@ module.exports = function(bucket, options) {
 
       s3.getObject(params, function(err, data) {
         getStream.pending--;
-        if (err && err.statusCode !== 404) return next(AwsError(err, params));
+        if (err && err.statusCode === 404) return next();
         if (err) return getStream.emit('error', AwsError(err, params));
         getStream.push(data);
         getStream.got++;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,3 +104,17 @@ test('purging fixtures - please be patient...', function(assert) {
     });
   });
 });
+
+test('get stream no-op on 404', function(assert) {
+  var getter = s3scan.Get(bucket, { agent: agent })
+    .on('data', function(d) {
+      assert.fail('no data should be transmitted');
+    })
+    .on('error', function(err) {
+      assert.ifError(err, 'no error should arise');
+    })
+    .on('finish', function() { assert.end(); });
+
+  getter.write([prefix, testId, 'does-not-exist'].join('/'));
+  getter.end();
+});


### PR DESCRIPTION
This is likely to mean that an object was deleted between the time that its key was listed and the time that you got around to fetching it.
