### PR TITLE
Purge --dryrun

### DIFF
--- a/bin/s3purge.js
+++ b/bin/s3purge.js
@@ -16,9 +16,10 @@ if (!s3url) {
 }
 
 var quiet = process.argv[3] === '--quiet' || process.argv[3] === '-q';
+var dryrun = process.argv[3] === '--dryrun' || process.argv[3] === '-d';
 var interval;
 
-var purge = s3scan.Purge(s3url, agent, function(err) {
+var purge = s3scan.Purge(s3url, { agent: agent, dryrun: dryrun }, function(err) {
   if (!quiet) clearInterval(interval);
   setTimeout(function() {
     console.log(quiet ? purge.deleted : '');
@@ -27,7 +28,13 @@ var purge = s3scan.Purge(s3url, agent, function(err) {
   }, 600);
 });
 
-if (!quiet) {
+if (dryrun) {
+  purge.on('deleted', function(key) {
+    console.log(key);
+  });
+}
+
+if (!quiet && !dryrun) {
   interval = setInterval(function() {
     process.stdout.write(util.format('\r\033[KDeleted %s @ %s/s', purge.deleted, purge.rate()));
   }, 500);

--- a/index.js
+++ b/index.js
@@ -95,26 +95,24 @@ module.exports.Scan = function(s3url, agent) {
  *   console.log('deleted all the things!');
  * });
  */
-module.exports.Purge = function(s3url, agent, callback) {
-  if (typeof agent === 'function') {
-    callback = agent;
-    agent = null;
+module.exports.Purge = function(s3url, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
   }
 
   var bucket = s3urls.fromUrl(s3url).Bucket;
   if (!bucket) throw new Error('Invalid s3url');
-
-  var options = agent ? { agent: agent } : undefined;
 
   function done(err) {
     if (callback) return callback(err);
     if (err) throw err;
   }
 
-  var del = Delete(bucket, options)
+  var del = Delete(bucket, opts)
     .on('error', callback || function() {})
     .on('finish', callback || function() {});
-  var list = List(s3url, options)
+  var list = List(s3url, opts)
     .on('error', callback || function() {});
 
   list.pipe(Split()).pipe(del);

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -49,6 +49,7 @@ module.exports = function(bucket, options) {
         deleteStream.pending--;
         if (err && err.statusCode !== 404) return next(awsError(err, params));
         deleteStream.deleted++;
+        deleteStream.emit('deleted', key);
         next();
       });
     });

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -53,8 +53,8 @@ module.exports = function(bucket, options) {
         next();
       }
 
-      if (!options.dryrun) s3.deleteObject(params, removed);
-      else removed();
+      if (options.dryrun) return removed();
+      s3.deleteObject(params, removed);
     });
 
     callback();

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -45,13 +45,16 @@ module.exports = function(bucket, options) {
         Key: key
       };
 
-      s3.deleteObject(params, function(err, data) {
+      function removed(err) {
         deleteStream.pending--;
         if (err && err.statusCode !== 404) return next(awsError(err, params));
         deleteStream.deleted++;
         deleteStream.emit('deleted', key);
         next();
-      });
+      }
+
+      if (!options.dryrun) s3.deleteObject(params, removed);
+      else removed();
     });
 
     callback();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,6 +88,29 @@ test('scan objects', function(assert) {
     });
 });
 
+test('[dryrun] purging fixtures - please be patient...', function(assert) {
+  var deletedEvents = 0;
+  var remainingObjects = 0;
+
+  s3scan.Purge(uri, { agent: agent, dryrun: true }, function(err) {
+    assert.ifError(err, 'success');
+
+    var params = s3urls.fromUrl(uri);
+
+    s3scan.List(uri, { agent: agent })
+      .on('data', function(keys) {
+        remainingObjects += keys.toString().trim().split('\n').length;
+      })
+      .on('end', function() {
+        assert.equal(deletedEvents, Object.keys(fixtures).length, 'all deleted events fired');
+        assert.equal(remainingObjects, Object.keys(fixtures).length, 'no items removed');
+        assert.end();
+      });
+  }).on('deleted', function() {
+    deletedEvents++;
+  });
+});
+
 test('purging fixtures - please be patient...', function(assert) {
   var deletedEvents = 0;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,6 +89,8 @@ test('scan objects', function(assert) {
 });
 
 test('purging fixtures - please be patient...', function(assert) {
+  var deletedEvents = 0;
+
   s3scan.Purge(uri, agent, function(err) {
     assert.ifError(err, 'success');
 
@@ -99,9 +101,12 @@ test('purging fixtures - please be patient...', function(assert) {
       Prefix: params.Key
     }, function(err, data) {
       if (err) throw err;
+      assert.equal(deletedEvents, Object.keys(fixtures).length, 'all deleted events fired');
       assert.equal(data.Contents.length, 0, 'all items removed');
       assert.end();
     });
+  }).on('deleted', function() {
+    deletedEvents++;
   });
 });
 


### PR DESCRIPTION
Allow a flag to do a delete as a dry run, where instead of actually deleting anything, it just logs out the keys that would have been deleted.
