### PR TITLE
Adds copy stream

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,3 +1,19 @@
+## `s3scan.Copy`
+
+Provides a writable stream that accepts keys and copies them to another location.
+
+### Parameters
+
+* `fromBucket` **`string`** the bucket to copy objects from
+* `toBucket` **`string`** the bucket to copy objects into
+* `keyTransform` **`[function]`** a function to transform keys. The function you provide should accept a source key and synchronously return the desired destination key. If not provided, objects in the `fromBucket` will be copied to the `toBucket` as-is.
+* `options` **`[object]`** options to provide to the writable stream.
+
+
+
+Returns `object` a writable stream
+
+
 ## `s3scan.Delete`
 
 Provides a writable stream that expects you to write line-delimited S3 keys

--- a/index.js
+++ b/index.js
@@ -131,3 +131,18 @@ module.exports.Purge = function(s3url, options, callback) {
   list.pipe(Split()).pipe(del);
   return del;
 };
+
+/**
+ * Provides a writable stream that accepts keys and copies them to another location.
+ *
+ * @name s3scan.Copy
+ * @param {string} fromBucket - the bucket to copy objects from
+ * @param {string} toBucket - the bucket to copy objects into
+ * @param {function} [keyTransform] - a function to transform keys. The
+ * function you provide should accept a source key and synchronously return the
+ * desired destination key. If not provided, objects in the `fromBucket` will be
+ * copied to the `toBucket` as-is.
+ * @param {object} [options] - options to provide to the writable stream.
+ * @returns {object} a writable stream
+ */
+module.exports.Copy = require('./lib/copy');

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,0 +1,77 @@
+var stream = require('stream');
+var queue = require('queue-async');
+var AWS = require('aws-sdk');
+var AwsError = require('./error');
+
+module.exports = function(fromBucket, toBucket, keyTransform, options) {
+  if (typeof keyTransform === 'object') {
+    options = keyTransform;
+    keyTransform = function(key) { return key; };
+  }
+
+  var s3config = {};
+  if (options && options.agent) s3config.httpOptions = { agent: options.agent };
+  var s3 = options && options.s3 || new AWS.S3(s3config);
+
+  var starttime = Date.now();
+  var copyStream = new stream.Writable(options);
+  copyStream.copied = 0;
+  copyStream.pending = 0;
+  copyStream.queue = queue();
+  copyStream.queue.awaitAll(function(err) { if (err) copyStream.emit('error', err); });
+
+  copyStream.rate = function() {
+    var duration = (Date.now() - starttime) / 1000;
+    return (copyStream.copied / duration).toFixed(2);
+  };
+
+  copyStream._write = function(key, enc, callback) {
+    key = key.toString().trim();
+    if (!key.length) return callback();
+
+    if (copyStream.pending > 1000)
+      return setImmediate(copyStream._write.bind(copyStream), key, enc, callback);
+
+    copyStream.pending++;
+    copyStream.queue.defer(function(next) {
+      var getParams = {
+        Bucket: fromBucket,
+        Key: key.toString()
+      };
+
+      s3.getObject(getParams, function(err, data) {
+        if (err) {
+          copyStream.pending--;
+          return next(AwsError(err, getParams));
+        }
+
+        var putParams = {
+          Bucket: toBucket,
+          Key: keyTransform(key.toString()),
+          Body: data.Body
+        };
+
+        s3.putObject(putParams, function(err) {
+          copyStream.pending--;
+          if (err) return next(AwsError(err, putParams));
+          copyStream.copied++;
+          next();
+        });
+      });
+    });
+
+    callback();
+  };
+
+  var end = copyStream.end.bind(copyStream);
+  copyStream.end = function() {
+    if (!copyStream.pending) return end();
+
+    copyStream.queue.awaitAll(function(err) {
+      if (err) return copyStream.emit('error', err);
+      end();
+    });
+  };
+
+  return copyStream;
+};


### PR DESCRIPTION
A writable stream that accepts line-delimited keys and copies files to some other destination on S3. When creating the stream you provide:
- the bucket to copy from
- the bucket to copy into
- optionally, a function that defines a transformation on a single key. This can be used to adjust keys on the destination side of the copy operation.

TODO: tests!

cc @willwhite 
