### PR TITLE
Protect against a premature end to key listing 

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -2,6 +2,7 @@ var AWS = require('aws-sdk');
 var stream = require('stream');
 var s3urls = require('s3urls');
 var awsError = require('./error.js');
+var assert = require('assert');
 
 module.exports = function(s3url, options) {
   var s3config = {};
@@ -57,14 +58,24 @@ module.exports = function(s3url, options) {
       keyStream.readPending = false;
 
       if (more) keyStream.next = last.Key;
-      else {
-        var response = this;
-        console.log(response.httpResponse.statusCode);
-        console.log(response.httpResponse.body.toString());
-        console.log(JSON.stringify(data));
-        keyStream.done = true;
-      }
+      else keyStream.done = true;
       keyStream._read();
+    }).on('extractData', function(res) {
+      // See https://github.com/aws/aws-sdk-js/issues/886
+      try {
+        assert.deepEqual(res.data, { Contents: [], CommonPrefixes: [] });
+        res.data = null;
+        res.error = {
+          code: 'TruncatedResponseError',
+          message: 'ListObjects response body was incomplete'
+        };
+      } catch (err) {
+        return;
+      }
+    }).on('retry', function(res) {
+      if (res.error) {
+        if (res.error.code === 'TruncatedResponseError') res.error.retryable = true;
+      }
     });
   };
 

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -57,7 +57,13 @@ module.exports = function(s3url, options) {
       keyStream.readPending = false;
 
       if (more) keyStream.next = last.Key;
-      else keyStream.done = true;
+      else {
+        var response = this;
+        console.log(response.httpResponse.statusCode);
+        console.log(response.httpResponse.body.toString());
+        console.log(JSON.stringify(data));
+        keyStream.done = true;
+      }
       keyStream._read();
     });
   };


### PR DESCRIPTION
This patch circumvents a bug in aws-sdk: https://github.com/aws/aws-sdk-js/issues/886. The result is that  the key listing stream (and therefore the scan stream), would occasionally stop providing keys prematurely, and complete without error.

cc @ian29 @emilymdubois 
