### PR TITLE
Adjust error expectations for aws-sdk@2.2.35

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -60,22 +60,6 @@ module.exports = function(s3url, options) {
       if (more) keyStream.next = last.Key;
       else keyStream.done = true;
       keyStream._read();
-    }).on('extractData', function(res) {
-      // See https://github.com/aws/aws-sdk-js/issues/886
-      try {
-        assert.deepEqual(res.data, { Contents: [], CommonPrefixes: [] });
-        res.data = null;
-        res.error = {
-          code: 'TruncatedResponseError',
-          message: 'ListObjects response body was incomplete'
-        };
-      } catch (err) {
-        return;
-      }
-    }).on('retry', function(res) {
-      if (res.error) {
-        if (res.error.code === 'TruncatedResponseError') res.error.retryable = true;
-      }
     });
   };
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/mapbox/s3scan#readme",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
-    "aws-sdk": "^2.1.40",
+    "aws-sdk": "^2.2.35",
     "queue-async": "1.0.7",
     "s3urls": "^1.3.0",
     "split": "^1.0.0"

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -94,11 +94,11 @@ test('[errors] truncated get', function(assert) {
   get.end();
 });
 
-test('[errors] truncated list', function(assert) {
+test('[errors] truncated list response', function(assert) {
   var mock = this;
   var list = Keys('s3://bucket/list-truncated', { s3: mock.client });
   list.on('error', function(err) {
-    assert.equal(err.code, 'TruncatedResponseError', 'truncated error');
+    assert.equal(err.code, 'XMLParserError', 'xml parsing error');
     assert.equal(mock.attempts, 4, 'tried 4 times');
     assert.end();
   });


### PR DESCRIPTION
aws-sdk-js no longer presents a truncated ListObjects response in a way that could be interpreted as the end of the keys. Now there's a retryable `XMLParserError`.
