### PR TITLE
bin/s3scan.js

### DIFF
--- a/bin/s3scan.js
+++ b/bin/s3scan.js
@@ -11,7 +11,7 @@ var argv = require('minimist')(process.argv);
 
 var s3url = argv._[2];
 if (!s3url) {
-  console.error('Usage: s3scan <s3url>');
+  console.error('Usage: s3scan <s3url> [--concurrency=num] [--gunzip]');
   process.exit(1);
 }
 

--- a/bin/s3scan.js
+++ b/bin/s3scan.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var keepalive = require('agentkeepalive');
+var agent = new keepalive.HttpsAgent({
+  keepAlive: true,
+  maxSockets: Math.ceil(require('os').cpus().length * 16),
+  keepAliveTimeout: 60000
+});
+var s3scan = require('..');
+var argv = require('minimist')(process.argv);
+
+var s3url = argv._[2];
+if (!s3url) {
+  console.error('Usage: s3scan <s3url>');
+  process.exit(1);
+}
+
+var options = { agent: agent, body: true };
+if (argv.gunzip) options.gunzip = new Boolean(argv.gunzip);
+if (argv.concurrency) options.concurrency = parseInt(argv.concurrency, 10);
+
+s3scan.Scan(s3url, options).pipe(process.stdout);

--- a/lib/get.js
+++ b/lib/get.js
@@ -11,24 +11,30 @@ var zlib = require('zlib');
  * @param {Object} options
  * @param {Object} options.agent An http agent to use for requests
  * @param {Number} options.concurrency Concurrency at which to request objects
+ * @param {Boolean} options.keys Include RequestParameters on response objects
  * @param {Boolean} options.gunzip Gunzip each object body
  * @param {Boolean} options.body Stream only the object body from response objects
+ * @param {Boolean} options.passErrors Include errors in object stream
  */
 module.exports = function(bucket, options) {
-  var s3config = {};
-  if (options && options.agent) s3config.httpOptions = { agent: options.agent };
-  var s3 = options && options.s3 || new AWS.S3(s3config);
+  options = options || {};
 
-  var concurrency = options && options.concurrency || undefined;
-  var gunzip = options && options.gunzip || false;
-  var body = options && options.body || false;
+  if (options.body && options.keys)
+    throw new Error('options.body cannot be used with options.keys');
+
+  if (options.body && options.passErrors)
+    throw new Error('options.body cannot be used with options.passErrors');
+
+  var s3config = {};
+  if (options.agent) s3config.httpOptions = { agent: options.agent };
+  var s3 = options.s3 || new AWS.S3(s3config);
 
   var starttime = Date.now();
   var getStream = new stream.Transform(options);
   getStream._readableState.objectMode = true;
   getStream.got = 0;
   getStream.pending = 0;
-  getStream.queue = queue(concurrency);
+  getStream.queue = queue(options.concurrency);
   getStream.queue.awaitAll(function(err) { if (err) getStream.emit('error', err); });
 
   getStream.rate = function() {
@@ -58,16 +64,16 @@ module.exports = function(bucket, options) {
         var response = err || data;
         if (options.keys) response.RequestParameters = params;
 
-        if (gunzip) {
+        if (options.gunzip) {
           zlib.gunzip(response.Body, function(err, gunzipped) {
             if (err) return getStream.emit('error', AwsError(err, params));
             response.Body = gunzipped;
-            getStream.push(body ? response.Body : response);
+            getStream.push(options.body ? response.Body : response);
             getStream.got++;
             next();
           });
         } else {
-          getStream.push(body ? response.Body : response);
+          getStream.push(options.body ? response.Body : response);
           getStream.got++;
           next();
         }

--- a/lib/get.js
+++ b/lib/get.js
@@ -2,18 +2,33 @@ var stream = require('stream');
 var queue = require('queue-async');
 var AWS = require('aws-sdk');
 var AwsError = require('./error');
+var zlib = require('zlib');
 
+/**
+ * Returns a get transform stream. Converts S3 keys to objects retrieved
+ * from a bucket via GET requests.
+ * @param {String} bucket
+ * @param {Object} options
+ * @param {Object} options.agent An http agent to use for requests
+ * @param {Number} options.concurrency Concurrency at which to request objects
+ * @param {Boolean} options.gunzip Gunzip each object body
+ * @param {Boolean} options.body Stream only the object body from response objects
+ */
 module.exports = function(bucket, options) {
   var s3config = {};
   if (options && options.agent) s3config.httpOptions = { agent: options.agent };
   var s3 = options && options.s3 || new AWS.S3(s3config);
+
+  var concurrency = options && options.concurrency || undefined;
+  var gunzip = options && options.gunzip || false;
+  var body = options && options.body || false;
 
   var starttime = Date.now();
   var getStream = new stream.Transform(options);
   getStream._readableState.objectMode = true;
   getStream.got = 0;
   getStream.pending = 0;
-  getStream.queue = queue();
+  getStream.queue = queue(concurrency);
   getStream.queue.awaitAll(function(err) { if (err) getStream.emit('error', err); });
 
   getStream.rate = function() {
@@ -43,9 +58,19 @@ module.exports = function(bucket, options) {
         var response = err || data;
         if (options.keys) response.RequestParameters = params;
 
-        getStream.push(response);
-        getStream.got++;
-        next();
+        if (gunzip) {
+          zlib.gunzip(response.Body, function(err, gunzipped) {
+            if (err) return getStream.emit('error', AwsError(err, params));
+            response.Body = gunzipped;
+            getStream.push(body ? response.Body : response);
+            getStream.got++;
+            next();
+          });
+        } else {
+          getStream.push(body ? response.Body : response);
+          getStream.got++;
+          next();
+        }
       }).on('extractData', function(res) {
         if (res.data.Body.length !== Number(res.data.ContentLength)) {
           res.data = null;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "bin": {
     "s3purge": "bin/s3purge.js",
-    "s3keys": "bin/s3keys.js"
+    "s3keys": "bin/s3keys.js",
+    "s3scan": "bin/s3scan.js"
   },
   "author": "Mapbox",
   "license": "ISC",
@@ -24,6 +25,7 @@
   "dependencies": {
     "agentkeepalive": "^2.0.3",
     "aws-sdk": "^2.2.35",
+    "minimist": "~1.2.0",
     "queue-async": "1.0.7",
     "s3urls": "^1.3.0",
     "split": "^1.0.0"

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,14 @@ $ s3keys s3://my-bucket/some-prefix
 $ s3purge s3://my-bucket/all-finished-with-these
 ```
 
+**s3scan**: GET and print a prefix-worth of objects to stdout
+
+```sh
+$ s3scan s3://my-bucket/some-prefix
+$ s3scan s3://my-bucket/some-prefix --gunzip
+$ s3scan s3://my-bucket/some-prefix --gunzip --concurrency=1
+```
+
 ## Running tests
 
 You can run tests against your own bucket/prefix by specifying them as environment variables:

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -94,6 +94,18 @@ test('[errors] truncated get', function(assert) {
   get.end();
 });
 
+test('[errors] truncated get, passErrors: true', function(assert) {
+  var mock = this;
+  var get = Get('-', { s3: mock.client, passErrors: true });
+  get.on('data', function(err) {
+    assert.equal(err.code, 'TruncatedResponseError', 'truncated error');
+    assert.equal(mock.attempts, 4, 'tried 4 times');
+    assert.end();
+  });
+  get.write('truncated/some/key');
+  get.end();
+});
+
 test('[errors] truncated list response', function(assert) {
   var mock = this;
   var list = Keys('s3://bucket/list-truncated', { s3: mock.client });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -140,7 +140,7 @@ test('scan objects, keys=true', function(assert) {
         return k[0] === '0';
       });
       assert.equal(found.length, keys.length, 'retrieved all RequestParameters');
-      assert.deepEqual(found, keys.sort(), 'found all expected keys in ascending order');
+      assert.equal(_.difference(found, keys).length, 0, 'found all expected keys');
       assert.end();
     });
 });


### PR DESCRIPTION
**Big picture:** makes it easier to stream logs, gzipped line-delimited json, and other text from multiple objects into a single stream off of S3. These are various tasks we've done downstream (e.g https://github.com/mapbox/cloudfront-log-reader) from `s3scan` and seems like we might as well just move it upstream.
- Adds optional `concurrency` option to `getStream`. Use `concurrency: 1` to stream objects in ascending key order.
- Adds optional `gunzip` option to `getStream`. Use to gunzip each object body on its way out.
- Adds optional `body` option to `getStream`. Use to turn a response-object-stream into just straight object contents.
- Adds `s3scan` command:
  
  ``` sh
  $ s3scan s3://my-bucket/some-prefix
  $ s3scan s3://my-bucket/some-prefix --gunzip
  $ s3scan s3://my-bucket/some-prefix --gunzip --concurrency=1
  ```

cc @rclark @ian29 
