### PR TITLE
Make optional options truly optional

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -4,14 +4,16 @@ var AWS = require('aws-sdk');
 var AwsError = require('./error');
 
 module.exports = function(fromBucket, toBucket, keyTransform, options) {
+  options = options || {};
+
   if (typeof keyTransform === 'object') {
     options = keyTransform;
     keyTransform = function(key) { return key; };
   }
 
   var s3config = {};
-  if (options && options.agent) s3config.httpOptions = { agent: options.agent };
-  var s3 = options && options.s3 || new AWS.S3(s3config);
+  if (options.agent) s3config.httpOptions = { agent: options.agent };
+  var s3 = options.s3 || new AWS.S3(s3config);
 
   var starttime = Date.now();
   var copyStream = new stream.Writable(options);

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -4,9 +4,11 @@ var AWS = require('aws-sdk');
 var awsError = require('./error.js');
 
 module.exports = function(bucket, options) {
+  options = options || {};
+
   var s3config = {};
-  if (options && options.agent) s3config.httpOptions = { agent: options.agent };
-  var s3 = options && options.s3 || new AWS.S3(s3config);
+  if (options.agent) s3config.httpOptions = { agent: options.agent };
+  var s3 = options.s3 || new AWS.S3(s3config);
 
   var starttime = Date.now();
   var deleteStream = new stream.Writable(options);

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -5,9 +5,11 @@ var awsError = require('./error.js');
 var assert = require('assert');
 
 module.exports = function(s3url, options) {
+  options = options || {};
+
   var s3config = {};
-  if (options && options.agent) s3config.httpOptions = { agent: options.agent };
-  var s3 = options && options.s3 || new AWS.S3(s3config);
+  if (options.agent) s3config.httpOptions = { agent: options.agent };
+  var s3 = options.s3 || new AWS.S3(s3config);
 
   s3url = s3urls.fromUrl(s3url);
 


### PR DESCRIPTION
This PR ensures that wherever options are documented as optional they are, in fact, optional.

I ran into a problem using this library when I didn't provide options. This was the root of it. I just provided an empty object to fix the problem.

Do you think it's worth writing tests to ensure the behavior? I didn't know if the default options might not work well in the testing env ...

cc @rclark
