### PR TITLE
Capture http response info if SDK returns invalid data

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -50,6 +50,15 @@ module.exports = function(s3url, options) {
     s3.listObjects(params, function(err, data) {
       if (err) return keyStream.emit('error', awsError(err, params));
 
+      if (!Array.isArray(data.Contents)) {
+        var error = new Error('Invalid SDK response');
+        error.body = this.httpResponse.body;
+        error.headers = this.httpResponse.headers;
+        error.statusCode = this.httpResponse.statusCode;
+        error.requestId = this.requestId;
+        return keyStream.emit('error', error);
+      }
+
       var last = data.Contents.slice(-1)[0];
       var more = data.IsTruncated && last;
 


### PR DESCRIPTION
I realized that if we handle an SDK response that contains no `.Contents` array, `keys.js` will be forced to treat that response as the end of pagination. We've seen this happening somewhere in the middle of listing all the keys in a prefix, so we _definitely want to fail loudly_ and be forced to restart if we encounter this.

This PR adds catches the failure case and passes information about the HTTP response through on the error object. This ought be be logged downstream so we can boil the scenario down to a test case.

cc @yhahn @ianshward 
Refs #17 