### PR TITLE
Test to trigger invalid SDK response

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -71,6 +71,12 @@ module.exports = function(s3url, options) {
       if (more) keyStream.next = last.Key;
       else keyStream.done = true;
       keyStream._read();
+    }).on('httpDone', function(response) {
+      if (response.httpResponse.statusCode === 200 && !response.httpResponse.body.length) {
+        response.error = new Error('S3 API response contained no body');
+        response.error.retryable = true;
+        response.error.requestId = this.requestId;
+      }
     });
   };
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -11,7 +11,8 @@ function mock() {
     var routes = {
       timeout: /^\/timeout/,
       truncated: /^\/truncated/,
-      listTruncated: /^\/\?prefix=list-truncated/
+      listTruncated: /^\/\?prefix=list-truncated/,
+      empty: /^\/\?prefix=empty/
     };
 
     if (routes.timeout.test(req.url)) {
@@ -33,6 +34,11 @@ function mock() {
       return req.socket.destroy();
     }
 
+    if (routes.empty.test(req.url)) {
+      res.writeHead(200);
+      return res.end();
+    }
+    console.log(req.url);
     res.writeHead(404);
     res.end();
   });
@@ -112,6 +118,20 @@ test('[errors] truncated list response', function(assert) {
   list.on('error', function(err) {
     assert.equal(err.code, 'XMLParserError', 'xml parsing error');
     assert.equal(mock.attempts, 4, 'tried 4 times');
+    assert.end();
+  });
+  list.on('end', function() {
+    assert.fail('should not complete successfully');
+    assert.end();
+  });
+  list.resume();
+});
+
+test('[errors] truncated list response', function(assert) {
+  var mock = this;
+  var list = Keys('s3://bucket/empty/', { s3: mock.client });
+  list.on('error', function(err) {
+    assert.equal(err.message, 'Invalid SDK response');
     assert.end();
   });
   list.on('end', function() {

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -127,11 +127,12 @@ test('[errors] truncated list response', function(assert) {
   list.resume();
 });
 
-test('[errors] truncated list response', function(assert) {
+test('[errors] no body in the response', function(assert) {
   var mock = this;
   var list = Keys('s3://bucket/empty/', { s3: mock.client });
   list.on('error', function(err) {
-    assert.equal(err.message, 'Invalid SDK response');
+    assert.equal(err.message, 'S3 API response contained no body');
+    assert.equal(mock.attempts, 4, 'tried 4 times');
     assert.end();
   });
   list.on('end', function() {


### PR DESCRIPTION
@xrwang caught an example of the new `Invalid SDK response` from #18 in action. The clue was that the error object had `undefined` headers and body.

This PR adds a test that confirms that if S3 were to respond to the SDK with a 200 and no body, the SDK will not error, and will provide your callback function with `{}` -- an invalid response per SDK contract.

https://github.com/aws/aws-sdk-js/issues/1216

cc @ianshward 