### PR TITLE
Fix list stream object mode

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -30,7 +30,8 @@ module.exports = function(s3url, options) {
       var key = keyStream.cache.shift();
       if (!key) continue;
       if (options.objectMode) key = { Bucket: s3url.Bucket, Key: key };
-      keepReading = keyStream.push(key + '\n');
+      else key = key + '\n';
+      keepReading = keyStream.push(key);
       keyStream.listed++;
     }
 


### PR DESCRIPTION
A bug in listing streams with `objectMode: true` would yield `[object Object]\n` chunks instead of bucket/key objects.