### PR TITLE
CLOUDPLAT-3162: add npm OIDC publish workflow (s3scan)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,13 @@
+name: NPM release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  npm-release:
+    uses: mapbox/gha-public/.github/workflows/workflow-npm-oidc-publish.yml@main
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      create-github-release: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to s3scan
+
+## Development
+
+```bash
+npm ci
+npm test
+```
+
+## Releasing a new version
+
+Releases are published to npm via GitHub Actions.
+
+### Steps
+
+1. **Bump the version** in `package.json` (follow [semver](https://semver.org))
+2. **Update `CHANGELOG.md`** with a summary of what changed
+3. **Open a PR**, get it reviewed and merged to `master`
+4. **Trigger the release** from the [Actions tab](../../actions/workflows/npm-release.yml):
+   - Select **NPM release** → **Run workflow** → run from `master`
+
+The workflow will publish to npm and create a GitHub release with auto-generated notes.
+
+> **Note:** Only Mapbox maintainers with write access to this repository can trigger the release workflow. External contributors can open and contribute to PRs, but releases are always cut by the owning team.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/s3scan",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Streaming operations on S3 objects",
   "main": "index.js",
   "engines": {
@@ -39,5 +39,8 @@
     "eslint": "^8.52.0",
     "tape": "^4.6.3",
     "underscore": "^1.13.6"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Adds the reusable [`workflow-npm-oidc-publish`](https://github.com/mapbox/gha-public/blob/main/.github/workflows/workflow-npm-oidc-publish.yml) workflow from `mapbox/gha-public`.

This replaces local/manual `npm publish` with a GitHub Actions workflow using OIDC Trusted Publishing — no npm tokens required.

**Trigger:** manual (`workflow_dispatch`) — run from the Actions tab to publish.

Ticket: https://mapbox.atlassian.net/browse/CLOUDPLAT-3162