### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (s3scan)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,5 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/s3scan",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Streaming operations on S3 objects",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.